### PR TITLE
update the luigi version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as fobj:
     LONG_DESCRIPTION = fobj.read()
 
 INSTALL_REQUIRES = [
-    "luigi<=2.8.7",
+    "luigi @ git+https://github.com/spotify/luigi",
     "numpy<=1.17.0",
     "pandas==0.25.0",
     "requests==2.22.0",


### PR DESCRIPTION
Waiting a new release of luigi +2.8.8, you can depend of the upstream Git repo of luigi.

These lines https://github.com/spotify/luigi/commit/63007974de73444b06175e0163150023d58d4721 fixed the issue for the Tornado version between luigi and notebook.

In this case, the version of tornado can be `>=5.0` and `<6.0`.

fix #2 